### PR TITLE
Adapt documentation to make it clear how to use hexcodes

### DIFF
--- a/lights.js
+++ b/lights.js
@@ -12,7 +12,7 @@ if (argv.h || argv.help) {
 	process.stdout.write(`\
 Usage: coup-lights [color]
 
-color can be 6 digits ('ffcc00'), 3 digits ('fc0') or something like 'red'.
+color can be 6 digits ('#ffcc00'), 3 digits ('#fc0') or something like 'red'.
 If you don't pass a color, a random one will be picked.\n`)
 	process.exit(0)
 }


### PR DESCRIPTION
I tried to change the color:

```
~ $ /usr/local/lib/node_modules/coup-lights/lights.js green
~ $ /usr/local/lib/node_modules/coup-lights/lights.js --help
Usage: coup-lights [color]

color can be 6 digits ('ffcc00'), 3 digits ('fc0') or something like 'red'.
If you don't pass a color, a random one will be picked.
~ $ /usr/local/lib/node_modules/coup-lights/lights.js 088
Error: color should be a string
~ $ /usr/local/lib/node_modules/coup-lights/lights.js '088'
Error: color should be a string
~ $ /usr/local/lib/node_modules/coup-lights/lights.js "088"
Error: color should be a string
~ $ /usr/local/lib/node_modules/coup-lights/lights.js "008888"
Error: color should be a string
~ $ /usr/local/lib/node_modules/coup-lights/lights.js "#008888"
~ $ /usr/local/lib/node_modules/coup-lights/lights.js "#088"
```

So the documentation was not clear how to use. Let's be honest about the right way.